### PR TITLE
Added cross product for two vectors in R3

### DIFF
--- a/include/Vector.h
+++ b/include/Vector.h
@@ -23,6 +23,8 @@ public:
 
     double operator*(const Vector &vector);
 
+    Vector cross(const Vector &vector);
+
     friend std::ostream& operator<<(std::ostream& stream, const Vector &vector);
 };
 

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -52,3 +52,12 @@ ostream& operator<<(ostream& stream, const Vector &vector) {
     stream << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
     return stream;
 }
+
+Vector Vector::cross(const Vector &vector) {
+    Vector result;
+    result.x = (this->y * vector.z) - (this->z * vector.y);
+    result.y = (this->z * vector.x) - (this->x * vector.z);
+    result.z = (this->x * vector.y) - (this->y * vector.x);
+
+    return result;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,12 +13,14 @@ int main() {
     Vector v4 = v1 - v2;
     Vector v5 = v2;
     double scalar_product = v1*v2;
+    Vector v6 = v1.cross(v2);
 
     // Print results
     cout << v3 << endl;
     cout << v4 << endl;
     cout << v5 << endl;
     cout << scalar_product << endl;
+    cout << v6 << endl;
 
     return 0;
 }


### PR DESCRIPTION
I used cross() instead of the operator overloade as I didn't see any symbol that would be unambiguous for denoting cross product.