### PR TITLE
Changed the way of accessing products

### DIFF
--- a/include/Vector.h
+++ b/include/Vector.h
@@ -21,9 +21,9 @@ public:
 
     Vector operator-(const Vector &vector);
 
-    double operator*(const Vector &vector);
+    Vector operator*(const Vector &vector);
 
-    Vector cross(const Vector &vector);
+    double scalar_product(const Vector &vector);
 
     friend std::ostream& operator<<(std::ostream& stream, const Vector &vector);
 };

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -39,11 +39,11 @@ Vector Vector::operator-(const Vector &vector) {
     return result;
 }
 
-double Vector::operator*(const Vector &vector) {
-    double result = 0;
-    result += this->x * vector.x;
-    result += this->y * vector.y;
-    result += this->z * vector.z;
+Vector Vector::operator*(const Vector &vector) {
+    Vector result;
+    result.x = (this->y * vector.z) - (this->z * vector.y);
+    result.y = (this->z * vector.x) - (this->x * vector.z);
+    result.z = (this->x * vector.y) - (this->y * vector.x);
 
     return result;
 }
@@ -53,11 +53,11 @@ ostream& operator<<(ostream& stream, const Vector &vector) {
     return stream;
 }
 
-Vector Vector::cross(const Vector &vector) {
-    Vector result;
-    result.x = (this->y * vector.z) - (this->z * vector.y);
-    result.y = (this->z * vector.x) - (this->x * vector.z);
-    result.z = (this->x * vector.y) - (this->y * vector.x);
+double Vector::scalar_product(const Vector &vector) {
+    double result = 0;
+    result += this->x * vector.x;
+    result += this->y * vector.y;
+    result += this->z * vector.z;
 
     return result;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,8 @@ int main() {
     Vector v3 = v1 + v2;
     Vector v4 = v1 - v2;
     Vector v5 = v2;
-    double scalar_product = v1*v2;
-    Vector v6 = v1.cross(v2);
+    double scalar_product = v1.scalar_product(v2);
+    Vector v6 = v1 * v2;
 
     // Print results
     cout << v3 << endl;


### PR DESCRIPTION
Changed vector product to be accessible via the * operator and scala product via a function (switched order). Did this, because all other operator overloads also return type Vector -> **consistency**.